### PR TITLE
Get-LWHypervVM - fix for cluster vm not found returning TRUE

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -771,10 +771,10 @@ function Get-LWHypervVM
     $isCluster = (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue)
     if ($Name.Count -gt 0 -and -not $vm -and $isCluster)
     {
-        Get-ClusterGroup | Where-Object -Property GroupType -eq 'VirtualMachine' | Get-VM
+        $ClusteredVMs = Get-ClusterGroup | Where-Object -Property GroupType -eq 'VirtualMachine' | Get-VM 
     }
 
-    if (-not $vm -and -not $DisableClusterCheck -and $isCluster -and (Get-ClusterGroup @param))
+    if ($ClusteredVMs.Name -like "$Name" -and -not $vm -and -not $DisableClusterCheck -and $isCluster -and (Get-ClusterGroup @param))
     {
         $vm = Get-VM @param -CimSession (Get-ClusterGroup @param).OwnerNode.Name
     }


### PR DESCRIPTION
this cmdlet would return a list of VM's on the cluster -even if the vm did not exist- which would result in it being evaluated to ($true).

Expanded the search for the cluster VM and created a variable out of the list of VM's in the cluster.

<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description

Please describe your changes in detail, unless the title is already descriptive enough.

- [x] - I have tested my changes when a VM does not exist
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [X] - The PR has a meaningful title.  
- [X] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [X] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Setup a HyperV Failover Cluster

execute the following command:
```powershell
$DomainName = "contoso.com"           # must be in FQDN format. Example: contoso.com
$DomainControllerComputerName         = "CONTOSO01"

New-LabDefinition -Name TestEnv -DefaultVirtualizationEngine HyperV -VmPath "C:\ClusterStorage\Volume1\AutomatedLabs"

#setup internal lab network
Add-LabVirtualNetworkDefinition -Name 'LabInternal'

# Domain Controller
Add-LabMachineDefinition -Network LabInternal -Name $DomainControllerComputerName -OperatingSystem "Windows Server 2022 Standard" -Memory 6GB -Roles RootDC -DomainName $DomainName -Processors 4

Install-Lab -BaseImages -NetworkSwitches -VMs -Domains -NoValidation -verbose -debug
```

See the lab is now created successfully