### PR TITLE
Remove-LWHypervVM variable $machine and replaced with $name parameter

### DIFF
--- a/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
+++ b/AutomatedLabWorker/AutomatedLabWorkerVirtualMachines.psm1
@@ -823,7 +823,8 @@ function Remove-LWHypervVM
     $doNotAddToCluster = Get-LabConfigurationItem -Name DoNotAddVmsToCluster -Default $false
     if (-not $doNotAddToCluster -and (Get-Command -Name Get-Cluster -ErrorAction SilentlyContinue) -and (Get-Cluster -ErrorAction SilentlyContinue))
     {
-        $null = Get-ClusterGroup -Name $machine.ResourceName | Remove-ClusterGroup -RemoveResources -Force
+        Write-PSFMessage "Removing Clustered Resource: $Name"
+        $null = Get-ClusterGroup -Name $Name | Remove-ClusterGroup -RemoveResources -Force
     }
 
     Write-PSFMessage "Removing VM files for '$($Name)'"


### PR DESCRIPTION
removed $machine.resourcename which doesn't exist in the function context and can result in full clustered resource removal. Replaced with $Name which will evaluate to the machine name that is passed to it. Without using $Name I experienced all my clustered VM's removed instead of just lab ones! 

It may be worth adding additional checks for the removal to ensure only lab resources are going to be targeted.

<!---
1. Please ensure that your PR points to our develop branch. If not, please retarget the branch in the upper left corner.
2. Please ensure that the develop branch of your fork is up to date!
  a. git checkout develop
  b. git remote add upstream https://github.com/automatedlab/automatedlab.git
  c. git pull --rebase upstream develop
  d. Work on any merge conflicts and follow the on-screen instructions of the git client
  e. git push [--force, overwriting any changes you did to develop that were not part of our branch]
  f. git checkout <YOURBRANCH>
  g. git pull --rebase origin develop
  h. Work on any merge conflicts and git push again
  i. Open PR
3. Please provide a meaningful title for the PR. If you fix an issue, please reference it with (Fixes #nnn)
 -->
## Description
Attempting to use AutomatedLab 5.42 resulted in removal of all clustered HyperV VM's, even ones that are outside the lab. Troubleshooting found two issues. 
#1 - Get-LWHyperVLab would return all VM's and when passed into Remove-LWHyperVLab it would remove all clustered VM's. Fixed issue in Get-LWHyperVLab.
#2 - Remove-LWHyperVLab refers to a variable not passed into the function. If the $machine variable is not set or not in scope then clustered objects you were not expecting can be removed

#1 is fixed via another pull request.
#2 is addressed in this pull request.

Please describe your changes in detail, unless the title is already descriptive enough.

- [x ] - I have tested my changes.  
- [ ] - I have updated CHANGELOG.md and added my change to the Unreleased section
- [x ] - The PR has a meaningful title.  
- [ ] - I updated my fork/branch and have integrated all changes from AutomatedLab/develop before creating the PR.

## Type of change
<!--- Check all that apply. -->

- [x ] Bug fix  
- [ ] New functionality  
- [ ] Breaking change
- [ ] Documentation

## How was the change tested?
<!--
Please describe what you did to test your change, if applicable.
We are aware that there are currently no unit and integration tests, so we need
your help.
By letting us know how you tested, we can better judge what we need to test in
addition to that.
 -->

Testing was done manually by myself in my homelab environment. Home lab is a 3-node clustered HyperV environment. 